### PR TITLE
Enable secondary fire when swapping off Winston

### DIFF
--- a/src/heroes/winston/base.opy
+++ b/src/heroes/winston/base.opy
@@ -8,6 +8,7 @@ def CleanupWinston():
     CleanupHealthPools()
     eventPlayer.setMaxHealth(100)
     eventPlayer.allowButton(Button.SECONDARY_FIRE)
+    eventPlayer.setSecondaryFireEnabled(true)
     wait()
     eventPlayer.HeroActive = null
 


### PR DESCRIPTION
Fixes the bug where secondary fire cant be used when swapping hero after having used Winstons Zap ability.