### PR TITLE
Created Standardized Movespeed System

### DIFF
--- a/src/dev.opy
+++ b/src/dev.opy
@@ -61,6 +61,7 @@ rule "Dev HUD elements":
     @Condition devMode
 
     hudSubheader(getAllPlayers(), "Load: {0} - Avg: {1} - Peak: {2}".format(getServerLoad(), getAverageServerLoad(), getPeakServerLoad()), HudPosition.TOP, 5, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+    hudSubheader(localPlayer, "Speed: {0}".format(localPlayer.getSpeed()), HudPosition.TOP, 5, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
     hudSubheader(getAllPlayers(), "Text: {0} - Entity Count: {1} - {2}".format(getNumberOfTextIds(), getNumberOfEntityIds(), "Damage Mods: {0} - Healing Mods: {1} Heal over time: {2}".format(getNumberOfDamageModificationIds(), getNumberOfHealingModificationIds(), getNumberOfHoTIds())), HudPosition.TOP, 4, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
     hudSubheader(getAllPlayers(), "Change hero - Jump + Reload + Crouch", HudPosition.TOP, 7, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
     hudSubheader(getAllPlayers(), "Spawn bot - Crouch + Interact", HudPosition.TOP, 8, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)

--- a/src/general/4M6QT.opy
+++ b/src/general/4M6QT.opy
@@ -9,37 +9,26 @@ globalvar _objectVariable_2
 globalvar _objectVariable_3
 globalvar _objectVariable_4
 globalvar ActiveModifications
-globalvar LastMoveSpeedModificationID
 globalvar antiCrashActivated
 globalvar ForbiddenUltimateHeroes
 globalvar ForbiddenAbility1Heroes
 globalvar ForbiddenAbility2Heroes
-globalvar slot
-globalvar c
-globalvar cIndex
-globalvar c_0
-globalvar cIndex_0
-globalvar MoveSpeed
 globalvar UltChargeReqArray
 
 #Player variables
 
 playervar _extendedPlayerCollection
 playervar SupportHealingID
-playervar DamageMoveSpeedID
 playervar NextUltCharge
 playervar HeroEffects
 playervar HeroTexts
 playervar HeroHealthPools
 playervar HeroDamageModifications
 playervar HeroHealingModifications
-playervar HeroMoveSpeedModifications
-playervar BaptisteMoveSpeedID
 playervar EchoLastHealth
 playervar ReinhardtFirestrikeCharges
 playervar ReinhardtFirestrikeCooldown
 playervar CastingUltimate
-playervar OrisaMoveSpeedID
 playervar Galloping
 playervar HealingPercents
 playervar DegenerationEnabled
@@ -70,6 +59,12 @@ playervar DuplicateTimer
 playervar DuplicateFacing
 playervar DuplicateVals
 playervar DuplicatePassiveCharge
+playervar roadhogCloudEntity
+playervar _ActiveSpeedMod
+playervar MultSpeedMod
+playervar AddSpeedMod
+playervar HeroAbsoluteSpeedMod
+playervar LucioBoost
 
 
 #Subroutine names
@@ -84,7 +79,6 @@ playervar DuplicatePassiveCharge
 #subroutine CleanupBaptiste
 subroutine CleanupEffects
 subroutine CleanupHealingMods
-subroutine CleanupMoveSpeedMods
 subroutine SlowdownBaptiste
 subroutine ReturnBaptisteToNormalSpeed
 #subroutine InitialReinhardt
@@ -102,8 +96,6 @@ subroutine CleanupDamageMods
 #subroutine CleanupMercy
 #subroutine InitialSymmetra
 #subroutine CleanupSymmetra
-subroutine FlankerSetup
-subroutine FlankerCleanup
 #subroutine InitialSombra
 #subroutine CleanupSombra
 #subroutine InitialLucio
@@ -124,14 +116,16 @@ rule "Initial Global":
     _classIndexes[1000] = 0
     _classIndexes[0] = -1
     ActiveModifications = []
-    LastMoveSpeedModificationID = 0
     antiCrashActivated = false
     ForbiddenUltimateHeroes = [Hero.DOOMFIST, Hero.DVA, Hero.PHARAH, Hero.JUNKRAT]
     ForbiddenAbility1Heroes = [Hero.REINHARDT, Hero.TRACER]
     ForbiddenAbility2Heroes = [Hero.TRACER]
     UltChargeReqArray = [2100, 1260, 1820, 1680, 2142, 1540, 2100, 1540, 1540, 2310, 1680, 2310, 1932, 1800, 1680, 1925, 2100, 2310, 2940, 1540, 1610, 1400, 1680, 2100, 1680, 2800, 2380, 1540, 2240, 1960, 2310, 1960]
     progressBarHud(localPlayer if localPlayer.DuplicateTimer and localPlayer.isAlive() else null, localPlayer.DuplicateTimer * (100 / 15), "Duplicating: {0}".format(15 if localPlayer.DuplicateTimer > 15 else ceil(localPlayer.DuplicateTimer)), HudPosition.TOP, 3, Color.ORANGE, Color.WHITE, ProgressHudReeval.VISIBILITY_VALUES_AND_COLOR, SpecVisibility.DEFAULT)
-
+    
+    if devMode:
+        hudSubheader(localPlayer, "HeroSpeedMod: {0}".format(localPlayer.HeroAbsoluteSpeedMod), HudPosition.TOP, 5, Color.WHITE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT)
+ 
 
 rule "Initial Player":
     @Event eachPlayer
@@ -142,7 +136,6 @@ rule "Initial Player":
     eventPlayer.HeroHealthPools = []
     eventPlayer.HeroDamageModifications = []
     eventPlayer.HeroHealingModifications = []
-    eventPlayer.HeroMoveSpeedModifications = []
     eventPlayer.EchoLastHealth = 200
     eventPlayer.ReinhardtFirestrikeCharges = 2
     eventPlayer.ReinhardtFirestrikeCooldown = 6
@@ -154,8 +147,26 @@ rule "Initial Player":
     eventPlayer.WallrideTimer = 0
     eventPlayer.ZaryaBubbleCharges = 2
     eventPlayer.ZaryaBubbleCooldown = 5
+    eventPlayer.roadhogCloudEntity = []
+    eventPlayer.MultSpeedMod = 1
+    eventPlayer.HeroAbsoluteSpeedMod = 100
+    eventPlayer.AddSpeedMod = 0
+ 
 
+rule "Speed Modifications Setter":
+    @Event eachPlayer
+    @Condition eventPlayer._ActiveSpeedMod != (eventPlayer.MultSpeedMod * 100 + eventPlayer.AddSpeedMod) * (eventPlayer.HeroAbsoluteSpeedMod / 100)
+    
+    eventPlayer._ActiveSpeedMod = (eventPlayer.MultSpeedMod * 100 + eventPlayer.AddSpeedMod) * (eventPlayer.HeroAbsoluteSpeedMod / 100)
+    eventPlayer.setMoveSpeed(eventPlayer._ActiveSpeedMod)
+    if RULE_CONDITION:
+        goto RULE_START
+    wait()
+    if RULE_CONDITION:
+        goto RULE_START
 
+    
+    
 def CleanupEffects():
     @Name "[all.del] Subroutine: Cleanup Effects"
     
@@ -171,19 +182,6 @@ def CleanupHealingMods():
         stopHealingModification(eventPlayer.HeroHealingModifications[eventPlayer._extendedPlayerCollection[4]])
         eventPlayer._extendedPlayerCollection[4] += 1
     eventPlayer.HeroHealingModifications = []
-
-
-def CleanupMoveSpeedMods():
-    @Name "[all.del] Subroutine: Cleanup Move Speed Modifications"
-    
-    eventPlayer._extendedPlayerCollection[5] = 0
-    while eventPlayer._extendedPlayerCollection[5] < len(eventPlayer.HeroMoveSpeedModifications):
-        eventPlayer._extendedPlayerCollection[6] = 0
-        while eventPlayer._extendedPlayerCollection[6] < len([].concat(eventPlayer)):
-            ActiveModifications.remove(([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.HeroMoveSpeedModifications[eventPlayer._extendedPlayerCollection[5]]])[0])
-            eventPlayer._extendedPlayerCollection[6] += 1
-        eventPlayer._extendedPlayerCollection[5] += 1
-    eventPlayer.HeroMoveSpeedModifications = []
 
 
 def CleanupHealthPools():
@@ -216,38 +214,3 @@ def CleanupDamageMods():
         stopDamageModification(eventPlayer.HeroDamageModifications[eventPlayer._extendedPlayerCollection[9]])
         eventPlayer._extendedPlayerCollection[9] += 1
     eventPlayer.HeroDamageModifications = []
-
-
-def FlankerCleanup():
-    @Name "[flanker.del] Subroutine: Cleanup"
-    
-    CleanupMoveSpeedMods()
-
-
-def FlankerSetup():
-    @Name "[flanker.del] Subroutine: Setup"
-    
-    eventPlayer._extendedPlayerCollection[12] = 0
-    while eventPlayer._extendedPlayerCollection[12] < len([].concat(eventPlayer)):
-        LastMoveSpeedModificationID += 1
-        eventPlayer._extendedPlayerCollection[13] = _classIndexes.index(0)
-        _classIndexes[eventPlayer._extendedPlayerCollection[13]] = 8
-        _objectVariable_3[eventPlayer._extendedPlayerCollection[13]] = []
-        _objectVariable_4[eventPlayer._extendedPlayerCollection[13]] = 0
-        _objectVariable_1[eventPlayer._extendedPlayerCollection[13]] = [].concat(eventPlayer)[eventPlayer._extendedPlayerCollection[12]]
-        _objectVariable_0[eventPlayer._extendedPlayerCollection[13]] = LastMoveSpeedModificationID
-        _objectVariable_2[eventPlayer._extendedPlayerCollection[13]] = 91.709
-        ActiveModifications.append(eventPlayer._extendedPlayerCollection[13])
-        eventPlayer._extendedPlayerCollection[12] += 1
-    eventPlayer.HeroMoveSpeedModifications.append(LastMoveSpeedModificationID)
-    async(FlankerCleanup, AsyncBehavior.NOOP)
-
-
-def InitialTracer():
-    @Name "[flanker.del] Subroutine: Initial Tracer"
-    FlankerSetup()
-
-
-def InitialGenji():
-    @Name "[flanker.del] Subroutine: Initial Genji"
-    FlankerSetup()

--- a/src/general/resets.opy
+++ b/src/general/resets.opy
@@ -95,6 +95,8 @@ def CleanSlate():
         eventPlayer.allowButton(Button.ULTIMATE)
         eventPlayer.allowButton(Button.INTERACT)
 
+        eventPlayer.HeroAbsoluteSpeedMod = 100
+
         eventPlayer.setDamageDealt(100)
         eventPlayer.setGravity(100)
         eventPlayer.setJumpVerticalSpeed(100)
@@ -110,7 +112,12 @@ rule "Player changed hero":
     @Condition (eventPlayer.hero != eventPlayer.getCurrentHero())
     do:
         #Here a cleanup subroutine will be called, this should be defined by each developer for their specific hero, called CleanupHERO (all hero names are spelled with one Capital then all lowercase)
-
+        if eventPlayer.hero in getDamageHeroes(): 
+            if eventPlayer.hero not in [Hero.TRACER, Hero.GENJI]:
+                eventPlayer.MultSpeedMod /= (1 + rolePassivesDamageMovementSpeed/100)
+            else:
+                eventPlayer.MultSpeedMod /= 5.5*(1 + rolePassivesDamageMovementSpeed/100)/6
+        
         switch eventPlayer.hero:
             case Hero.REAPER:
                 CleanupReaper()
@@ -217,6 +224,12 @@ rule "Player changed hero":
 
         #Here an initializer subroutine will be called, this should be defined by each developer for their specific hero, called InitialHERO (all hero names are spelled with one Capital then all lowercase)
         eventPlayer.hero = eventPlayer.getCurrentHero()
+        
+        if eventPlayer.hero in getDamageHeroes(): 
+            if eventPlayer.hero not in [Hero.TRACER, Hero.GENJI]:
+                eventPlayer.MultSpeedMod *= (1 + rolePassivesDamageMovementSpeed/100)
+            else:
+                eventPlayer.MultSpeedMod *= 5.5*(1 + rolePassivesDamageMovementSpeed/100)/6
         
         switch eventPlayer.hero:
             case Hero.REAPER:

--- a/src/heroes/baptiste/base.opy
+++ b/src/heroes/baptiste/base.opy
@@ -7,25 +7,10 @@ def CleanupBaptiste():
   CleanupEffects()
   eventPlayer.allowButton(Button.ABILITY_2)
   CleanupHealingMods()
-  CleanupMoveSpeedMods()
 
 
 def InitialBaptiste():
   @Name "[baptiste.del] Subroutine: Initial"
-  eventPlayer._extendedPlayerCollection[2] = 0
-  while eventPlayer._extendedPlayerCollection[2] < len([].concat(eventPlayer)):
-      LastMoveSpeedModificationID += 1
-      eventPlayer._extendedPlayerCollection[3] = _classIndexes.index(0)
-      _classIndexes[eventPlayer._extendedPlayerCollection[3]] = 8
-      _objectVariable_3[eventPlayer._extendedPlayerCollection[3]] = []
-      _objectVariable_4[eventPlayer._extendedPlayerCollection[3]] = 0
-      _objectVariable_1[eventPlayer._extendedPlayerCollection[3]] = [].concat(eventPlayer)[eventPlayer._extendedPlayerCollection[2]]
-      _objectVariable_0[eventPlayer._extendedPlayerCollection[3]] = LastMoveSpeedModificationID
-      _objectVariable_2[eventPlayer._extendedPlayerCollection[3]] = 100
-      ActiveModifications.append(eventPlayer._extendedPlayerCollection[3])
-      eventPlayer._extendedPlayerCollection[2] += 1
-  eventPlayer.BaptisteMoveSpeedID = LastMoveSpeedModificationID
-  eventPlayer.HeroMoveSpeedModifications.append(LastMoveSpeedModificationID)
   #Healing modification to self
   startHealingModification(eventPlayer, eventPlayer, 50, HealingReeval.RECEIVERS_AND_HEALERS)
   eventPlayer.HeroHealingModifications.append(getLastHealingModification())

--- a/src/heroes/baptiste/immortality.opy
+++ b/src/heroes/baptiste/immortality.opy
@@ -4,32 +4,22 @@
 def SlowdownBaptiste():
   @Name "[baptiste.del] Subroutine: Slowdown"
   
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = 100
   eventPlayer.frac = 1
   chase(eventPlayer.frac, 0.25, duration=1, ChaseReeval.DESTINATION_AND_DURATION)
   while eventPlayer.frac > 0.25:
-      if not (eventPlayer.getCurrentHero() == Hero.BAPTISTE):
-          break
-      _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = (4 * eventPlayer.frac * eventPlayer.frac * eventPlayer.frac if eventPlayer.frac < 0.5 else 1 - ((((-2 * eventPlayer.frac + 2) * (-2 * eventPlayer.frac + 2)) * (-2 * eventPlayer.frac + 2)) / 2)) * 100
-      eventPlayer.setMoveSpeed((4 * eventPlayer.frac * eventPlayer.frac * eventPlayer.frac if eventPlayer.frac < 0.5 else 1 - ((((-2 * eventPlayer.frac + 2) * (-2 * eventPlayer.frac + 2)) * (-2 * eventPlayer.frac + 2)) / 2)) * 100)
+      eventPlayer.AddSpeedMod -= 100/62.5
       wait()
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = 100
   stopChasingVariable(eventPlayer.frac)
 
 
 def ReturnBaptisteToNormalSpeed():
   @Name "[baptiste.del] Subroutine: Transition to Normal Speed"
   
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = 0
   eventPlayer.frac_0 = 0.25
   chase(eventPlayer.frac_0, 1, duration=1, ChaseReeval.DESTINATION_AND_DURATION)
   while eventPlayer.frac_0 < 1:
-      if not (eventPlayer.getCurrentHero() == Hero.BAPTISTE):
-          break
-      _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = (4 * eventPlayer.frac_0 * eventPlayer.frac_0 * eventPlayer.frac_0 if eventPlayer.frac_0 < 0.5 else 1 - ((((-2 * eventPlayer.frac_0 + 2) * (-2 * eventPlayer.frac_0 + 2)) * (-2 * eventPlayer.frac_0 + 2)) / 2)) * 100
-      eventPlayer.setMoveSpeed((4 * eventPlayer.frac_0 * eventPlayer.frac_0 * eventPlayer.frac_0 if eventPlayer.frac_0 < 0.5 else 1 - ((((-2 * eventPlayer.frac_0 + 2) * (-2 * eventPlayer.frac_0 + 2)) * (-2 * eventPlayer.frac_0 + 2)) / 2)) * 100)
+      eventPlayer.AddSpeedMod += 100/62.5
       wait()
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.BaptisteMoveSpeedID])[0]] = 100
   stopChasingVariable(eventPlayer.frac_0)
 
 

--- a/src/heroes/damage.opy
+++ b/src/heroes/damage.opy
@@ -1,41 +1,4 @@
 #!mainFile "../main.opy"
 
 
-globalvar rolePassivesDamageMovementSpeed = 100 + createWorkshopSetting(int[0:100], "Role passives", "Damage movement speed bonus", 15, 0)
-
-subroutine setRolePassiveMovementSpeed
-
-def setRolePassiveMovementSpeed():
-  @Name "Subroutine - set movementspeed based on role passive"
-
-  eventPlayer.setMoveSpeed(rolePassivesDamageMovementSpeed if eventPlayer.getCurrentHero() in getDamageHeroes() else 100)
-
-
-rule "[all.del] Damage Passive":
-  @Event eachPlayer
-  @Condition (eventPlayer.getCurrentHero() in getDamageHeroes()) == true
-  
-  if not eventPlayer.DamageMoveSpeedID:
-      eventPlayer._extendedPlayerCollection[0] = 0
-      while eventPlayer._extendedPlayerCollection[0] < len([].concat(eventPlayer)):
-          LastMoveSpeedModificationID += 1
-          eventPlayer._extendedPlayerCollection[1] = _classIndexes.index(0)
-          _classIndexes[eventPlayer._extendedPlayerCollection[1]] = 8
-          _objectVariable_3[eventPlayer._extendedPlayerCollection[1]] = []
-          _objectVariable_4[eventPlayer._extendedPlayerCollection[1]] = 0
-          _objectVariable_1[eventPlayer._extendedPlayerCollection[1]] = [].concat(eventPlayer)[eventPlayer._extendedPlayerCollection[0]]
-          _objectVariable_0[eventPlayer._extendedPlayerCollection[1]] = LastMoveSpeedModificationID
-          _objectVariable_2[eventPlayer._extendedPlayerCollection[1]] = rolePassivesDamageMovementSpeed
-          ActiveModifications.append(eventPlayer._extendedPlayerCollection[1])
-          eventPlayer._extendedPlayerCollection[0] += 1
-      eventPlayer.DamageMoveSpeedID = LastMoveSpeedModificationID
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.DamageMoveSpeedID])[0]] = rolePassivesDamageMovementSpeed
-  
-  setRolePassiveMovementSpeed() # Temp fix for movementspeed not applying cause I don't get what's going on here
-
-  waitUntil(not eventPlayer.getCurrentHero() in getDamageHeroes(), 9999)
-  _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.DamageMoveSpeedID])[0]] = 100
-  
-  setRolePassiveMovementSpeed() # Temp fix for movementspeed not applying cause I don't get what's going on here
-
-  waitUntil(not eventPlayer.getCurrentHero() in getDamageHeroes(), 9999)
+globalvar rolePassivesDamageMovementSpeed = createWorkshopSetting(int[0:100], "Role passives", "Damage movement speed bonus", 15, 0)

--- a/src/heroes/doomfist/rocket-punch.opy
+++ b/src/heroes/doomfist/rocket-punch.opy
@@ -14,7 +14,7 @@ rule "Doomfist Vertical Rocket Punch":
     #Player cancels Rocket Punch, gets CC'd or hacked; Stop execution
     if eventPlayer.hasStatusEffect(Status.STUNNED) or eventPlayer.hasStatusEffect(Status.ROOTED) or eventPlayer.hasStatusEffect(Status.KNOCKED_DOWN) or eventPlayer.hasStatusEffect(Status.FROZEN) or eventPlayer.hasStatusEffect(Status.ASLEEP) or eventPlayer.hasStatusEffect(Status.HACKED) or eventPlayer.isHoldingButton(Button.PRIMARY_FIRE):
         return
-    eventPlayer.setMoveSpeed(0)
+    eventPlayer.HeroAbsoluteSpeedMod = 0
     if not eventPlayer.DFDidHitPlayer:
         #If Doomfist is punching upwards, impulse in the direction until he gets off the ground
         if eventPlayer.getFacingDirection().y > 0.05:
@@ -23,7 +23,7 @@ rule "Doomfist Vertical Rocket Punch":
                 wait(0.05)
         eventPlayer.applyImpulse(eventPlayer.getFacingDirection(), 50, Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION)
     wait(0.08)
-    setRolePassiveMovementSpeed()
+    eventPlayer.HeroAbsoluteSpeedMod = 100
     eventPlayer.DFDidHitPlayer = false
 
 rule "Rocket Punch":

--- a/src/heroes/lucio/base.opy
+++ b/src/heroes/lucio/base.opy
@@ -12,7 +12,6 @@ def CleanupLucio():
     CleanupHealingMods()
     CleanupEffects()
     CleanupHealthPools()
-    CleanupMoveSpeedMods()
     stopChasingVariable(eventPlayer.MusicMeter)
     stopChasingVariable(eventPlayer.WallrideTimer)
     eventPlayer.WallrideTimer = 0
@@ -36,19 +35,3 @@ def InitialLucio():
     eventPlayer.HeroTexts.append(getLastCreatedText())
     chase(eventPlayer.WallrideTimer, 1 if eventPlayer.isOnWall() else 0, rate=100 if eventPlayer.isOnWall() else 1, ChaseReeval.DESTINATION_AND_RATE)
     chase(eventPlayer.MusicMeter, 100 if eventPlayer.isOnWall() or (eventPlayer.isOnWall() and (eventPlayer.isUsingUltimate() or eventPlayer.isUsingAbility2())) else 0, rate=0 if eventPlayer.WallrideTimer > 0 and not eventPlayer.isOnWall() else musicMeterGain if eventPlayer.isOnWall() or (eventPlayer.isOnWall() and (eventPlayer.isUsingUltimate() or eventPlayer.isUsingAbility2())) else musicMeterDrain, ChaseReeval.DESTINATION_AND_RATE)
-    eventPlayer.Index = 0
-    while eventPlayer.Index < 5:
-        eventPlayer._extendedPlayerCollection[17] = 0
-        while eventPlayer._extendedPlayerCollection[17] < len([].concat(getPlayersInSlot(evalOnce(eventPlayer.Index), eventPlayer.getTeam()))):
-            LastMoveSpeedModificationID += 1
-            eventPlayer._extendedPlayerCollection[18] = _classIndexes.index(0)
-            _classIndexes[eventPlayer._extendedPlayerCollection[18]] = 8
-            _objectVariable_3[eventPlayer._extendedPlayerCollection[18]] = []
-            _objectVariable_4[eventPlayer._extendedPlayerCollection[18]] = 0
-            _objectVariable_1[eventPlayer._extendedPlayerCollection[18]] = [].concat(getPlayersInSlot(evalOnce(eventPlayer.Index), eventPlayer.getTeam()))[eventPlayer._extendedPlayerCollection[17]]
-            _objectVariable_0[eventPlayer._extendedPlayerCollection[18]] = LastMoveSpeedModificationID
-            _objectVariable_2[eventPlayer._extendedPlayerCollection[18]] = 100
-            ActiveModifications.append(eventPlayer._extendedPlayerCollection[18])
-            eventPlayer._extendedPlayerCollection[17] += 1
-        eventPlayer.HeroMoveSpeedModifications.append(LastMoveSpeedModificationID)
-        eventPlayer.Index += 1

--- a/src/heroes/lucio/speedboost.opy
+++ b/src/heroes/lucio/speedboost.opy
@@ -9,21 +9,22 @@ rule "[lucio.del] Speedboost":
     @Event eachPlayer
     @Hero lucio
     @Condition eventPlayer.isUsingAbility2() == true
+    @Condition eventPlayer.isInAlternateForm() == true
     
-    if not eventPlayer.isInAlternateForm():
-        return
     eventPlayer.SpeedboostBonus = speedboostMinGain * (1 - eventPlayer.MusicMeter / 100) + speedboostMaxGain * (eventPlayer.MusicMeter / 100) if eventPlayer.MusicMeter >= musicMeterGain else 0
-    while eventPlayer.isUsingAbility2():
-        eventPlayer._extendedPlayerCollection[20] = 0
-        while eventPlayer._extendedPlayerCollection[20] < len(eventPlayer.HeroMoveSpeedModifications):
-            #Boost speed based on the music meter charge
-            if distance(_objectVariable_1[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.HeroMoveSpeedModifications[eventPlayer._extendedPlayerCollection[20]]])[0]], eventPlayer.getPosition()) < 12 and not eventPlayer.isInAlternateForm():
-                _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.HeroMoveSpeedModifications[eventPlayer._extendedPlayerCollection[20]]])[0]] = 100 + eventPlayer.SpeedboostBonus
-            else:
-                _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.HeroMoveSpeedModifications[eventPlayer._extendedPlayerCollection[20]]])[0]] = 100
-            eventPlayer._extendedPlayerCollection[20] += 1
-        wait(0.25)
-    eventPlayer._extendedPlayerCollection[21] = 0
-    while eventPlayer._extendedPlayerCollection[21] < len(eventPlayer.HeroMoveSpeedModifications):
-        _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.HeroMoveSpeedModifications[eventPlayer._extendedPlayerCollection[21]]])[0]] = 100
-        eventPlayer._extendedPlayerCollection[21] += 1
+    waitUntil(not eventPlayer.isUsingAbility2(), 99999)
+
+rule "[lucio.del] Player affected by Speedboost":
+    @Event eachPlayer
+    @Condition (any([player.isUsingAbility2() and player.isInAlternateForm() and distance(player, eventPlayer) <= 12 for player in getPlayersOnHero(Hero.LUCIO, eventPlayer.getTeam())])) == true
+    
+    wait()
+    eventPlayer.LucioBoost = ([player for player in getPlayersOnHero(Hero.LUCIO, eventPlayer.getTeam()) if player.isUsingAbility2() and distance(player, eventPlayer) <= 12])[0]
+    eventPlayer.AddSpeedMod += eventPlayer.LucioBoost.SpeedboostBonus
+    waitUntil(not (any([player.isUsingAbility2() and player.isInAlternateForm() and distance(player, eventPlayer) <= 12 for player in getPlayersOnHero(Hero.LUCIO, eventPlayer.getTeam())])), 99999)
+    if (eventPlayer.LucioBoost.isUsingAbility2() and eventPlayer.isInAlternateForm()):
+        waitUntil(any([player.isUsingAbility2() and player.isInAlternateForm() and distance(player, eventPlayer) <= 12 for player in getPlayersOnHero(Hero.LUCIO, eventPlayer.getTeam())]), 1)
+    eventPlayer.AddSpeedMod -= eventPlayer.LucioBoost.SpeedboostBonus
+    eventPlayer.LucioBoost = false
+    if RULE_CONDITION:
+        goto RULE_START

--- a/src/heroes/mei/avalanche.opy
+++ b/src/heroes/mei/avalanche.opy
@@ -125,7 +125,7 @@ def ChaseAvalancheSpeed():
   
   #Gradually increase the player speed
   for eventPlayer.AvalancheSpeed in range(100, AvalancheMaxSpeed, (AvalancheMaxSpeed - 100) / (30 * AvalancheDuration)):
-      eventPlayer.setMoveSpeed(eventPlayer.AvalancheSpeed)
+      eventPlayer.HeroAbsoluteSpeedMod = eventPlayer.AvalancheSpeed / (1 + rolePassivesDamageMovementSpeed/100)
       wait()
 
 
@@ -147,7 +147,7 @@ def ClearAvalanche():
   eventPlayer.AvalancheTimer = 0
   eventPlayer.AvalancheFinalPosition = eventPlayer.getPosition()
   eventPlayer.stopForcingThrottle()
-  eventPlayer.setMoveSpeed(100)
+  eventPlayer.HeroAbsoluteSpeedMod = 100
   ExplodeAvalanche()
   #Destroy Effects
   destroyEffect(eventPlayer.AvalancheEffects)

--- a/src/heroes/mei/icing.opy
+++ b/src/heroes/mei/icing.opy
@@ -188,22 +188,15 @@ rule "Player is on Icing and Icing Type is set to slide":
     eventPlayer.startAcceleration(directionTowards(vect(0, 0, 0), evalOnce(eventPlayer.getThrottle() if eventPlayer.getThrottle() != vect(0, 0, 0) else vect(0, 0, 1))), 400, 200, Relativity.TO_PLAYER, AccelReeval.NONE)
     eventPlayer.startForcingThrottle(0, 0, 0, 0, 0, 0)
 
-    ChaseIcingSpeed()
-
-
-rule "Player is not on icing and Icing Type is set to slide":
-    @Event eachPlayer
-    @Condition IcingType == 0
-    @Condition eventPlayer.AvalancheTimer != true
-    @Condition eventPlayer.InIcingOfPlayer != null
-    @Condition any([distance(eventPlayer, player) < IcingRadius * 1.2 for player in getPlayersOnHero(Hero.MEI, eventPlayer.getTeam())[0].IcingStepPositions]) == false
-    
-    wait(0.064)
+    async(ChaseIcingSpeed, AsyncBehavior.NOOP)
+    waitUntil(not (IcingType == 0 and eventPlayer.isOnGround() and not eventPlayer.AvalancheTimer and any([len(player.IcingStepPositions) > 0 for player in getPlayersOnHero(Hero.MEI, eventPlayer.getTeam())]) and any([distance(eventPlayer, player) < IcingRadius for player in getPlayersOnHero(Hero.MEI, eventPlayer.getTeam())[0].IcingStepPositions])), 99999)
+    wait(0.032)
     eventPlayer.stopAcceleration()
     eventPlayer.InIcingOfPlayer = null
+    eventPlayer.AddSpeedMod -= eventPlayer.IcingCurrentSpeed
+    eventPlayer.IcingCurrentSpeed = 0
     #Don't reset speed is using Avalanche
     if eventPlayer.AvalancheTimer != true:
-        setRolePassiveMovementSpeed()
         eventPlayer.stopForcingThrottle()
 
 
@@ -212,13 +205,12 @@ rule "Speed up teammates walking on icing (if enabled)":
     @Condition IcingType == 1
     @Condition (any([player != 0 and distance(player, eventPlayer.getPosition()) < IcingRadius for player in ([player for player in getPlayers(eventPlayer.getTeam()) if player.hero == Hero.MEI and len(player.IcingStepPositions) > 0]).IcingStepPositions])) == true
     
-    eventPlayer.setMoveSpeed(rolePassivesDamageMovementSpeed if eventPlayer.getCurrentHero() in getDamageHeroes() else 100 + IcingSpeedIncrease)
-    wait(0.032)
+    eventPlayer.AddSpeedMod += IcingSpeedIncrease
+    waitUntil(not ((any([player != 0 and distance(player, eventPlayer.getPosition()) < IcingRadius for player in ([player for player in getPlayers(eventPlayer.getTeam()) if player.hero == Hero.MEI and len(player.IcingStepPositions) > 0]).IcingStepPositions])) and IcingType == 1), 99999)
+    eventPlayer.AddSpeedMod -= IcingSpeedIncrease
     if RULE_CONDITION:
         goto RULE_START
-    #Don't reset speed is using Avalanche
-    if eventPlayer.AvalancheTimer != true:
-        setRolePassiveMovementSpeed()
+    
 
 
 rule "Slow down enemies walking on icing (if enabled)":
@@ -226,11 +218,12 @@ rule "Slow down enemies walking on icing (if enabled)":
     @Condition IcingSlow > 0
     @Condition (any([player != 0 and distance(player, eventPlayer.getPosition()) < IcingRadius for player in ([player for player in getPlayers(getOppositeTeam(eventPlayer.getTeam())) if player.hero == Hero.MEI and len(player.IcingStepPositions) > 0]).IcingStepPositions])) == true
     
-    eventPlayer.setMoveSpeed(rolePassivesDamageMovementSpeed if eventPlayer.getCurrentHero() in getDamageHeroes() else 100 - IcingSlow)
-    wait(0.032)
+    eventPlayer.AddSpeedMod -= IcingSlow
+    waitUntil(not ((any([player != 0 and distance(player, eventPlayer.getPosition()) < IcingRadius for player in ([player for player in getPlayers(getOppositeTeam(eventPlayer.getTeam())) if player.hero == Hero.MEI and len(player.IcingStepPositions) > 0]).IcingStepPositions])) and IcingSlow > 0), 99999)
+    eventPlayer.AddSpeedMod += IcingSlow
     if RULE_CONDITION:
         goto RULE_START
-    setRolePassiveMovementSpeed()
+    
 
 
 def ClearIcing():
@@ -254,9 +247,14 @@ def ChaseIcingSpeed():
     @Name "Subroutine - Chase Icing Speed"
 
     #Slowly accelerate player between a range
-    for eventPlayer.IcingCurrentSpeed in range(IcingMinSpeed, IcingMaxSpeed, (IcingMaxSpeed - IcingMinSpeed) / 60):
-        eventPlayer.setMoveSpeed(eventPlayer.IcingCurrentSpeed)
-        wait(0.016, Wait.ABORT_WHEN_FALSE)
+    eventPlayer.AddSpeedMod += IcingMinSpeed - 100
+    eventPlayer.AddSpeedMod -= (IcingMaxSpeed-IcingMinSpeed) / 60
+    for eventPlayer.IcingCurrentSpeed in range(IcingMinSpeed - 100, IcingMaxSpeed - 100, (IcingMaxSpeed - IcingMinSpeed) / 60):
+        eventPlayer.AddSpeedMod += (IcingMaxSpeed-IcingMinSpeed) / 60
+        wait(0.016)
+        if not (IcingType == 0 and eventPlayer.isOnGround() and not eventPlayer.AvalancheTimer and any([len(player.IcingStepPositions) > 0 for player in getPlayersOnHero(Hero.MEI, eventPlayer.getTeam())]) and any([distance(eventPlayer, player) < IcingRadius for player in getPlayersOnHero(Hero.MEI, eventPlayer.getTeam())[0].IcingStepPositions])):
+            return
+    eventPlayer.AddSpeedMod += (IcingMaxSpeed-IcingMinSpeed) / 60
 
 
 def IcingFreezeAndDamageOnImpact():

--- a/src/heroes/orisa/base.opy
+++ b/src/heroes/orisa/base.opy
@@ -8,7 +8,6 @@ def CleanupOrisa():
     CleanupEffects()
     eventPlayer.allowButton(Button.ABILITY_2)
     eventPlayer.allowButton(Button.ULTIMATE)
-    CleanupMoveSpeedMods()
     eventPlayer.setProjectileGravity(100)
     eventPlayer.setDamageDealt(100)
     eventPlayer.setProjectileSpeed(100)
@@ -29,18 +28,4 @@ def InitialOrisa():
     hudSubtext(eventPlayer, "{0}({1})".format(" \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n                                                                                                                                                                                                                                                                                                                                      ", "Gallop"), HudPosition.LEFT, 1, Color.WHITE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT)
     eventPlayer.HeroTexts.append(getLastCreatedText())
     eventPlayer.setProjectileSpeed(125)
-    eventPlayer._extendedPlayerCollection[10] = 0
-    while eventPlayer._extendedPlayerCollection[10] < len([].concat(eventPlayer)):
-        LastMoveSpeedModificationID += 1
-        eventPlayer._extendedPlayerCollection[11] = _classIndexes.index(0)
-        _classIndexes[eventPlayer._extendedPlayerCollection[11]] = 8
-        _objectVariable_3[eventPlayer._extendedPlayerCollection[11]] = []
-        _objectVariable_4[eventPlayer._extendedPlayerCollection[11]] = 0
-        _objectVariable_1[eventPlayer._extendedPlayerCollection[11]] = [].concat(eventPlayer)[eventPlayer._extendedPlayerCollection[10]]
-        _objectVariable_0[eventPlayer._extendedPlayerCollection[11]] = LastMoveSpeedModificationID
-        _objectVariable_2[eventPlayer._extendedPlayerCollection[11]] = 100
-        ActiveModifications.append(eventPlayer._extendedPlayerCollection[11])
-        eventPlayer._extendedPlayerCollection[10] += 1
-    eventPlayer.OrisaMoveSpeedID = LastMoveSpeedModificationID
-    eventPlayer.HeroMoveSpeedModifications.append(LastMoveSpeedModificationID)
 

--- a/src/heroes/orisa/gallop.opy
+++ b/src/heroes/orisa/gallop.opy
@@ -43,15 +43,13 @@ rule "[orisa.del] Gallop":
     playEffect(getAllPlayers(), DynamicEffect.DEBUFF_IMPACT_SOUND, eventPlayer.getTeam(), eventPlayer.getEyePosition(), 500)
     playEffect(getAllPlayers(), DynamicEffect.ORISA_HALT_IMPLOSION_SOUND, eventPlayer.getTeam(), eventPlayer.getEyePosition(), 500)
     #Casting
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 0
-    eventPlayer.setMoveSpeed(0)
+    eventPlayer.HeroAbsoluteSpeedMod = 0
     eventPlayer.startFacing(vect(0, 0, 1), 500, Relativity.TO_PLAYER, FacingReeval.DIRECTION_AND_TURN_RATE)
     waitUntil(any([i == true for i in [eventPlayer.hasStatusEffect(Status.ASLEEP), eventPlayer.hasStatusEffect(Status.HACKED), eventPlayer.hasStatusEffect(Status.KNOCKED_DOWN), eventPlayer.hasStatusEffect(Status.STUNNED), eventPlayer.hasStatusEffect(Status.FROZEN)]]), orisaGallopDelay)
     eventPlayer.setDamageDealt(100)
     #Gallop
     eventPlayer.startForcingThrottle(1, 1, 0, 0, 0, 0)
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 500
-    eventPlayer.setMoveSpeed(500)
+    eventPlayer.HeroAbsoluteSpeedMod = 500
     eventPlayer.disablePlayerCollision()
     eventPlayer.forceButtonPress(Button.MELEE)
     eventPlayer.Galloping = true
@@ -71,8 +69,7 @@ rule "[orisa.del] Gallop":
     CleanupEffects()
     #Stop movement
     eventPlayer.stopForcingThrottle()
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 0
-    eventPlayer.setMoveSpeed(0)
+    eventPlayer.HeroAbsoluteSpeedMod = 0
     eventPlayer.enablePlayerCollision()
     eventPlayer.setAbilityCooldown(Button.MELEE, 0)
     eventPlayer.Galloping = false
@@ -83,8 +80,7 @@ rule "[orisa.del] Gallop":
     eventPlayer.stopCamera()
     #Set cooldown / restore movement
     eventPlayer.setAbilityCooldown(Button.ABILITY_2, 10)
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 100
-    eventPlayer.setMoveSpeed(100)
+    eventPlayer.HeroAbsoluteSpeedMod = 100
     eventPlayer.stopFacing()
     #Re-enable
     eventPlayer.setPrimaryFireEnabled(true)

--- a/src/heroes/orisa/primary.opy
+++ b/src/heroes/orisa/primary.opy
@@ -5,6 +5,7 @@ rule "[orisa.del] Decrease Primary Fire Movement Speed Penalty":
     @Hero orisa
     @Condition eventPlayer.isFiringPrimaryFire() == true
 
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 120
+    eventPlayer.HeroAbsoluteSpeedMod = 495/3.85
     waitUntil(not eventPlayer.isFiringPrimaryFire(), 9999)
-    _objectVariable_2[([player for player in ActiveModifications if _objectVariable_0[player] == eventPlayer.OrisaMoveSpeedID])[0]] = 100
+    if eventPlayer.HeroAbsoluteSpeedMod == 495/3.85:
+        eventPlayer.HeroAbsoluteSpeedMod = 100

--- a/src/heroes/roadhog/take-a-breather.opy
+++ b/src/heroes/roadhog/take-a-breather.opy
@@ -4,7 +4,6 @@
 globalvar roadhogBreatherCloudSize = createWorkshopSetting(float[1:50], "Roadhog", "Take a breather cloud size", 7.5, 0)
 
 
-playervar roadhogCloudEntity = []
 playervar roadhogMovementSpeed
 playervar roadhogCloudPos
 playervar roadhogCloudPlayersAffected
@@ -41,13 +40,12 @@ def RoadhogTakeABreather():
     eventPlayer.roadhogMovementSpeed = 100
     chase(eventPlayer.roadhogMovementSpeed, 0, duration=1.5, ChaseReeval.DESTINATION_AND_DURATION)
     while eventPlayer.roadhogMovementSpeed != 0:
-        eventPlayer.setMoveSpeed(eventPlayer.roadhogMovementSpeed)
+        eventPlayer.AddSpeedMod -= 100/47
         wait(0.032)
     chase(eventPlayer.roadhogMovementSpeed, 100, duration=1, ChaseReeval.DESTINATION_AND_DURATION)
     while eventPlayer.roadhogMovementSpeed != 100:
-        eventPlayer.setMoveSpeed(eventPlayer.roadhogMovementSpeed)
+        eventPlayer.AddSpeedMod += 100/32
         wait(0.032)
-    eventPlayer.setMoveSpeed(100)
     wait(createWorkshopSetting(float[2.5:9], "Roadhog", "Cloud duration", 5, 1) - 2.5)
     for eventPlayer.Index in range(len(eventPlayer.roadhogCloudEntity)):
         destroyEffect(eventPlayer.roadhogCloudEntity[eventPlayer.Index])

--- a/src/main.opy
+++ b/src/main.opy
@@ -2,14 +2,16 @@
 
 #!include "settings.opy"
 
-#!include "general/resets.opy"
 #!include "dev.opy"
 
+#!include "heroes/damage.opy"
+
 #!include "general/4M6QT.opy"
+#!include "general/resets.opy"
 
 #!include "heroes/tanks.opy"
 #!include "heroes/healers.opy"
-#!include "heroes/damage.opy"
+
 
 #!include "heroes/mercy/base.opy"
 #!include "heroes/mercy/primary-secondary.opy"


### PR DESCRIPTION
Many more deletions than additions. That's a good sign, eh?
- Added four variables to control movespeed across the board, and ported all movespeed modifications to this new system.
- Fixed various movespeed bugs, such as Tracer and Genji's movespeed being incorrect, and Avalanche resetting Mei's movespeed to normal (removing the dps movespeed bonus).
- Two listed features weren't even working. Orisa's primary penalty was supposed to go from 30% to 10%, but it was unchanged, and Lucio's music meter had no effect on the strength of his speed Amp. These features are now working.
- Removed more unnecessary variables related to my porting of movespeed modifications
- Removed the rest of the unused variables (other than the ones left there by ostw)


So, now that I've created two standardized systems, I suggest you add a readme.md or something including information that developers need to know about these two systems. This is the important information.

Important information for developers of this mode:

Hero swapping system:
When developing your hero, you need to make sure that hero swapping **_At any time_** is gracefully handled. Define two subroutines, Initial"HeroName" and Cleanup"HeroName", and the inbuilt system will call those rules in a consistent and guaranteed order. 

Movespeed modification system:
When you want to modify a player's movespeed, do so by setting one of the available player variables, and the inbuilt system will modify the actual movespeed of the player appropriately.

These are the movespeed variables used by the system and what conditions you are allowed to use them:
- _ActiveSpeedMod. Do not alter this variable, as it is only used by the system. It keeps track of the current movespeed multiplier for the hero after all three other variables are considered.
- MultSpeedMod. Allowed operations *= and /=. Can be used on self and others. Ex: *= 1.25 is a 25% boost. You must make sure that every *= or /= has an opposite action **_that is guaranteed to be called_** that returns it back to normal.
- AddSpeedMod. Allowed operations += and -=. Can be used on self and others. Stored in percentage points, Ex: += 20 is a 20% boost. You must make sure that every += or -= has an opposite action **_that is guaranteed to be called_** that returns it back to normal.
- HeroAbsoluteSpeedMod. Can be used **_only on self_**. Complete freedom to set this variable as you like. Stored in terms of percentage points. You can add 20 to boost by 20%, multiply by 1.2 to boost by 20%, or both to boost by 44%. It's up to you. When heroes are swapped, this variable will automatically be set back to base level.

The formula is (MultSpeedMod + AddSpeedMod) * HeroAbsoluteSpeedMod. This means MultSpeedMod is for speed modifications you'd like to stack multiplicatively with other MultSpeedMod actions, and AddSpeedMod is for buffs/debuffs that just stack additively. And HeroAbsoluteSpeedMod gets the final say in how fast your hero moves relative to all other modifications.  